### PR TITLE
Halite v4.3 as minimum, discussion opened for PHP version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
     "description": "Encrypted symfony entity's by verified and standardized libraries",
     "require": {
         "php": ">=7.0",
-        "paragonie/halite": "^3.4",
+        "paragonie/halite": "^4.3",
         "paragonie/sodium_compat": "^1.5",
         "doctrine/orm": "^2.5"
     },


### PR DESCRIPTION
As Halite v4.3 is the minimum version recommanded for this Bundle (see
#2) the PHP minimum requirements would be 7.2.

Another solution is using Defuse by default with allows a lower PHP
version, let's say 7.1 or even 7.0.

