### PR TITLE
docs: add secret key spec

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ ambta_doctrine_encrypt:
 
 ### Secret key
 
+The secret key should be a max 32 byte hexadecimal string (`[0-9a-fA-F]`).
+
 Secret key is generated if there is no key found. This is automatically generated and stored in the folder defined in the configuration
 
 ```yml


### PR DESCRIPTION
I was getting some odd errors because my secret key wasn't supported. Turns out there's fairly strict requirements to the secret key as a result of how `Hex::decode()` is used. https://github.com/paragonie/constant_time_encoding/issues/18