### PR TITLE
Allow custom encryptor from configuration

### DIFF
--- a/DependencyInjection/DoctrineEncryptExtension.php
+++ b/DependencyInjection/DoctrineEncryptExtension.php
@@ -34,7 +34,7 @@ class DoctrineEncryptExtension extends Extension
         if (in_array($config['encryptor_class'], array_keys(self::SupportedEncryptorClasses))) {
             $config['encryptor_class_full'] = self::SupportedEncryptorClasses[$config['encryptor_class']];
         } else {
-            $config['encryptor_class_full'] = self::SupportedEncryptorClasses['Halite'];
+            $config['encryptor_class_full'] = $config['encryptor_class'];
         }
 
         // Set parameters


### PR DESCRIPTION
Right now setting a custom `encryptor_class` in configuration will not override encryptor parameter (as said in docs) since every class not listed in `SupportedEncryptorClasses` will default to 'Halite'.   This change allows the use of a custom encryptor class defined in configuration as default.