### PR TITLE
Update Configuration.php

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -20,10 +20,14 @@ class Configuration implements ConfigurationInterface
      */
     public function getConfigTreeBuilder()
     {
-
         // Create tree builder
-        $treeBuilder = new TreeBuilder();
-        $rootNode = $treeBuilder->root('ambta_doctrine_encrypt');
+        $treeBuilder = new TreeBuilder('ambta_doctrine_encrypt');
+        if (\method_exists($treeBuilder, 'getRootNode')) {
+            $rootNode = $treeBuilder->getRootNode();
+        } else {
+            // BC layer for symfony/config 4.1 and older
+            $rootNode = $treeBuilder->root('ambta_doctrine_encrypt');
+        }
 
         // Grammar of config tree
         $rootNode


### PR DESCRIPTION
Fix for: A tree builder without a root node is deprecated since Symfony 4.2